### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end wit…

### DIFF
--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/InstanceListFragment.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/InstanceListFragment.java
@@ -191,6 +191,8 @@ public class InstanceListFragment extends Fragment implements LoaderManager.Load
             case R.id.action_donate:
                 DonationFragment.show(getFragmentManager());
                 return true;
+            default:
+                break;
         }
         return super.onOptionsItemSelected(item);
     }
@@ -208,6 +210,8 @@ public class InstanceListFragment extends Fragment implements LoaderManager.Load
                 case R.id.action_edit:
                     openEditorFragment(cursor.getString(0));
                     mMode.finish();
+                    break;
+                default:
                     break;
             }
             return true;

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/MainControllerFragment.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/MainControllerFragment.java
@@ -56,6 +56,8 @@ public class MainControllerFragment extends BaseControlFragment {
                 case R.id.tabsButton:
                     getClient().toggleTabs(mBlankResponseCallback);
                     break;
+                default:
+                    break;
             }
         }
     };
@@ -80,6 +82,8 @@ public class MainControllerFragment extends BaseControlFragment {
                     break;
                 case LEFT:
                     getClient().left(mBlankResponseCallback);
+                    break;
+                default:
                     break;
             }
         }

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/MovieControllerFragment.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/MovieControllerFragment.java
@@ -130,6 +130,8 @@ public class MovieControllerFragment extends BaseControlFragment {
                         }
                     });
                     break;
+                default:
+                    break;
             }
         }
     };

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/PlayerControllerFragment.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/PlayerControllerFragment.java
@@ -87,6 +87,8 @@ public class PlayerControllerFragment extends BaseControlFragment {
                 case R.id.backwardButton:
                     getClient().seek(-60, mBlankResponseCallback);
                     break;
+                default:
+                    break;
             }
         }
     };

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/SeriesControllerFragment.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/fragments/SeriesControllerFragment.java
@@ -39,6 +39,8 @@ public class SeriesControllerFragment extends BaseControlFragment {
                 case R.id.qualityButton:
                     getClient().toggleQuality(mBlankResponseCallback);
                     break;
+                default:
+                    break;
             }
         }
     };
@@ -63,6 +65,8 @@ public class SeriesControllerFragment extends BaseControlFragment {
                     break;
                 case LEFT:
                     getClient().prevSeason(mBlankResponseCallback);
+                    break;
+                default:
                     break;
             }
         }

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/widget/JoystickView.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/widget/JoystickView.java
@@ -294,6 +294,8 @@ public class JoystickView extends View {
             case RIGHT:
                 mRightImage = resource;
                 break;
+            default:
+                break;
         }
     }
 
@@ -319,6 +321,8 @@ public class JoystickView extends View {
                 case RIGHT:
                     mRightImage = bitmap;
                     break;
+                default:
+                    break;
             }
         } else {
             mCenterImage = null;
@@ -342,6 +346,8 @@ public class JoystickView extends View {
             case RIGHT:
                 mPositionY = mCenterY;
                 mPositionX = getWidth();
+                break;
+            default:
                 break;
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:SwitchLastCaseIsDefaultCheck - "switch" statements should end with a "default" clause

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:SwitchLastCaseIsDefaultCheck

Please let me know if you have any questions.

M-Ezzat