### PR TITLE
squid:S1125 - Literal boolean values should not be used in condition …

### DIFF
--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/utils/Base64.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/utils/Base64.java
@@ -288,7 +288,7 @@ public class Base64 {
 
         // If doPadding is false, set length to truncate '='
         // padding characters
-        while (doPadding == false && outLen > 0) {
+        while ( !doPadding && outLen > 0) {
             if (outBuff[outLen - 1] != '=') {
                 break;
             }

--- a/app/src/main/java/org/apache/commons/lang/builder/EqualsBuilder.java
+++ b/app/src/main/java/org/apache/commons/lang/builder/EqualsBuilder.java
@@ -105,7 +105,7 @@ public class EqualsBuilder {
      * @since 2.0
      */
     public EqualsBuilder appendSuper(boolean superEquals) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         isEquals = superEquals;
@@ -123,7 +123,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(Object lhs, Object rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -178,7 +178,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(long lhs, long rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         isEquals = (lhs == rhs);
@@ -193,7 +193,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(int lhs, int rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         isEquals = (lhs == rhs);
@@ -208,7 +208,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(short lhs, short rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         isEquals = (lhs == rhs);
@@ -223,7 +223,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(char lhs, char rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         isEquals = (lhs == rhs);
@@ -238,7 +238,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(byte lhs, byte rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         isEquals = (lhs == rhs);
@@ -259,7 +259,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(double lhs, double rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         return append(Double.doubleToLongBits(lhs), Double.doubleToLongBits(rhs));
@@ -279,7 +279,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(float lhs, float rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         return append(Float.floatToIntBits(lhs), Float.floatToIntBits(rhs));
@@ -293,7 +293,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(boolean lhs, boolean rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         isEquals = (lhs == rhs);
@@ -311,7 +311,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(Object[] lhs, Object[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -342,7 +342,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(long[] lhs, long[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -373,7 +373,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(int[] lhs, int[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -404,7 +404,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(short[] lhs, short[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -435,7 +435,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(char[] lhs, char[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -466,7 +466,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(byte[] lhs, byte[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -497,7 +497,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(double[] lhs, double[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -528,7 +528,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(float[] lhs, float[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {
@@ -559,7 +559,7 @@ public class EqualsBuilder {
      * @return EqualsBuilder - used to chain calls.
      */
     public EqualsBuilder append(boolean[] lhs, boolean[] rhs) {
-        if (isEquals == false) {
+        if (!isEquals) {
             return this;
         }
         if (lhs == rhs) {

--- a/app/src/main/java/org/apache/commons/lang/builder/HashCodeBuilder.java
+++ b/app/src/main/java/org/apache/commons/lang/builder/HashCodeBuilder.java
@@ -486,7 +486,7 @@ public class HashCodeBuilder {
             iTotal = iTotal * iConstant;
 
         } else {
-            if (object.getClass().isArray() == false) {
+            if (!object.getClass().isArray()) {
                 // the simple case, not an array, just the element
                 iTotal = iTotal * iConstant + object.hashCode();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1125 - Literal boolean values should not be used in condition expressions

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1125

Please let me know if you have any questions.

M-Ezzat