### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/Constants.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/Constants.java
@@ -1,11 +1,15 @@
 package eu.se_bastiaan.popcorntimeremote;
 
-public class Constants {
+public final class Constants {
 
     public static final Boolean LOG_ENABLED = BuildConfig.IS_DEBUG;
     public static final String PREFS_FILE = "PTRemote_Prefs";
     public static final String DATABASE_NAME = "PTRemote_DB.db";
     public static final Integer DATABASE_VERSION = 1;
     public static final String YOUTUBE_KEY = "AIzaSyC4GRG3DH0HyYvDpmLHqwmpKEhgpCBjduo";
+
+    private Constants() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
 }

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/database/InstanceEntry.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/database/InstanceEntry.java
@@ -2,11 +2,16 @@ package eu.se_bastiaan.popcorntimeremote.database;
 
 import android.provider.BaseColumns;
 
-public class InstanceEntry implements BaseColumns {
+public final class InstanceEntry implements BaseColumns {
     public static final String TABLE_NAME = "instances";
     public static final String COLUMN_NAME_NAME = "id";
     public static final String COLUMN_NAME_IP = "ip";
     public static final String COLUMN_NAME_PORT = "port";
     public static final String COLUMN_NAME_USERNAME = "username";
     public static final String COLUMN_NAME_PASSWORD = "password";
+
+    private InstanceEntry() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
 }

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/DonationItems.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/DonationItems.java
@@ -28,7 +28,11 @@ import eu.se_bastiaan.popcorntimeremote.R;
  *
  * @author Artem Chepurnoy
  */
-public class DonationItems {
+public final class DonationItems {
+
+    private DonationItems() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static Donation[] get(Resources res) {
         int[] data = new int[]{

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/utils/Security.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/utils/Security.java
@@ -40,11 +40,15 @@ import java.security.spec.X509EncodedKeySpec;
  * make it harder for an attacker to replace the code with stubs that treat all
  * purchases as verified.
  */
-public class Security {
+public final class Security {
     private static final String TAG = "IABUtil/Security";
 
     private static final String KEY_FACTORY_ALGORITHM = "RSA";
     private static final String SIGNATURE_ALGORITHM = "SHA1withRSA";
+
+    private Security() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     /**
      * Verifies that the data was signed with the given signature, and returns

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/CheatSheet.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/CheatSheet.java
@@ -31,12 +31,16 @@ import android.widget.Toast;
  * <p>Based on the original action bar implementation in <a href="https://android.googlesource.com/platform/frameworks/base/+/refs/heads/master/core/java/com/android/internal/view/menu/ActionMenuItemView.java">
  * ActionMenuItemView.java</a>.
  */
-public class CheatSheet {
+public final class CheatSheet {
     /**
      * The estimated height of a toast, in dips (density-independent pixels). This is used to
      * determine whether or not the toast should appear above or below the UI element.
      */
     private static final int ESTIMATED_TOAST_HEIGHT_DIPS = 48;
+
+    private CheatSheet() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     /**
      * Sets up a cheat sheet (tooltip) for the given view by setting its {@link

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/LogUtils.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/LogUtils.java
@@ -5,9 +5,13 @@ import android.util.Log;
 import eu.se_bastiaan.popcorntimeremote.Constants;
 
 
-public class LogUtils {
+public final class LogUtils {
 
     private static final String LOG_UTILS = "LogUtils";
+
+    private LogUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void d(Object message) {
         d(LOG_UTILS, message);

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/NetworkUtils.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/NetworkUtils.java
@@ -8,7 +8,11 @@ import java.net.NetworkInterface;
 import java.util.Collections;
 import java.util.List;
 
-public class NetworkUtils {
+public final class NetworkUtils {
+
+    private NetworkUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     /**
      * Returns MAC address of the given interface name.

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/PixelUtils.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/PixelUtils.java
@@ -11,7 +11,11 @@ import android.util.TypedValue;
 /**
  * Created by Sebastiaan on 11-06-14.
  */
-public class PixelUtils {
+public final class PixelUtils {
+
+    private PixelUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static int getPixelsFromDp(Context context, Integer dp) {
         Resources r = context.getResources();

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/PrefUtils.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/utils/PrefUtils.java
@@ -5,7 +5,11 @@ import android.content.Context;
 import eu.se_bastiaan.popcorntimeremote.Constants;
 import eu.se_bastiaan.popcorntimeremote.widget.ObscuredSharedPreferences;
 
-public class PrefUtils {
+public final class PrefUtils {
+
+    private PrefUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     // Main functions below
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat