### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/utils/Base64.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/utils/Base64.java
@@ -31,6 +31,8 @@ package eu.se_bastiaan.popcorntimeremote.iab.utils;
  * @version 1.3
  */
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Base64 converter class. This code is not a complete MIME encoder;
  * it simply converts binary data to base64 data and back.
@@ -427,7 +429,7 @@ public class Base64 {
      * @since 1.4
      */
     public static byte[] decode(String s) throws Base64DecoderException {
-        byte[] bytes = s.getBytes();
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
         return decode(bytes, 0, bytes.length);
     }
 
@@ -439,7 +441,7 @@ public class Base64 {
      * @return the decoded data
      */
     public static byte[] decodeWebSafe(String s) throws Base64DecoderException {
-        byte[] bytes = s.getBytes();
+        byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
         return decodeWebSafe(bytes, 0, bytes.length);
     }
 

--- a/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/utils/Security.java
+++ b/app/src/main/java/eu/se_bastiaan/popcorntimeremote/iab/utils/Security.java
@@ -22,6 +22,7 @@ package eu.se_bastiaan.popcorntimeremote.iab.utils;
 import android.text.TextUtils;
 import android.util.Log;
 
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
@@ -108,7 +109,7 @@ public final class Security {
         try {
             sig = Signature.getInstance(SIGNATURE_ALGORITHM);
             sig.initVerify(publicKey);
-            sig.update(signedData.getBytes());
+            sig.update(signedData.getBytes(StandardCharsets.UTF_8));
             if (!sig.verify(Base64.decode(signature))) {
                 Log.e(TAG, "Signature verification failed.");
                 return false;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat